### PR TITLE
Fix for vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "moment": "~2.4.0",
     "node-int64": "~0.3.0",
     "node-state": "~1.4.1",
-    "request": "~2.64.0",
+    "request": "~2.74.0",
     "snappystream": "^0.3.3",
     "underscore": "~1.5.2"
   }


### PR DESCRIPTION
nsqjs currently has a 4 vulnerable dependency paths, introducing 3 different types of known vulnerabilities.

This PR fixes vulnerable dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/dudleycarr/nsqjs) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade other dependencies as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)